### PR TITLE
[wifi-info] Add IP address text sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -300,6 +300,7 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+      entity_category: "diagnostic"
   - platform: version
     name: "ESPHome Version"
     hide_timestamp: true


### PR DESCRIPTION
## Summary

- Adds a `wifi_info` IP address text sensor to `Core.yaml`

## Test plan

- [ ] Confirm IP Address entity appears in Home Assistant after flashing
- [ ] Confirm entity shows the correct IP address

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ESPHome devices now expose their IP address information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->