### PR TITLE
[esphome] Modernise board spec, web server v3, remove legacy options

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -300,6 +300,16 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 script:
   - id: pumpUntilFull

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -295,6 +295,12 @@ light:
           min_brightness: 50%
           max_brightness: 100%
 
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+
 script:
   - id: pumpUntilFull
     then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -4,7 +4,6 @@ substitutions:
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
-  board: esp32-c6-devkitm-1
   variant: esp32c6
   flash_size: 8MB
   framework:
@@ -69,6 +68,7 @@ captive_portal:
 
 web_server:
   port: 80
+  version: 3
 
 # Buzzer
 output:

--- a/Integrations/ESPHome/PUMP-1.yaml
+++ b/Integrations/ESPHome/PUMP-1.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo PUMP-1
   comment: Apollo PUMP-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   on_boot:
   - priority: -10
     then:
@@ -48,11 +45,6 @@ update:
     source: https://apolloautomation.github.io/PUMP-1/firmware/manifest.json
 
 wifi:
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo PUMP-1 Hotspot"
 

--- a/Integrations/ESPHome/PUMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/PUMP-1_Minimal.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo PUMP-1
   comment: Apollo PUMP-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.PUMP-1"
     version: "${version}"


### PR DESCRIPTION
## Summary

- Remove redundant `esp32: board: esp32-c6-devkitm-1` string from Core.yaml (`variant: esp32c6` + `flash_size: 8MB` already present and sufficient)
- Add `version: 3` to `web_server:` in Core.yaml (inherited by both device variants)
- Remove `platformio_options: board_build.flash_mode: dio` from PUMP-1.yaml and PUMP-1_Minimal.yaml
- Remove legacy BLE wifi hooks (`on_connect: ble.disable` / `on_disconnect: ble.enable`) from PUMP-1.yaml

## Test plan

- [ ] `esphome config` validates cleanly for PUMP-1.yaml and PUMP-1_Minimal.yaml
- [ ] OTA flash succeeds on device
- [ ] Web server UI loads at device IP

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WiFi IP address, ESPHome version, and firmware version sensor information.

* **Updates**
  * Added explicit web server version configuration.
  * Updated pump control sequence behavior.
  * Removed device board specification and WiFi automation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->