### PR TITLE
Bump version to 26.3.2.1

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-pump-1
-  version: "25.12.18.1"
+  version: "26.3.2.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:


### PR DESCRIPTION
Version: 26.3.2.1

Adds:
Version number update to Core.yaml
Fixes:

Breaks:

Checks:
- [ ] Documentation Updated
- [x] Build Number Incremented In YAML (YY.MM.DD.#)