### PR TITLE
Fix Apollo Firmware Version sensor showing unknown

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -343,7 +343,6 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
-    update_interval: never
     entity_category: "diagnostic"
 
 script:


### PR DESCRIPTION
## Summary
- Removed `update_interval: never` from the Apollo Firmware Version text sensor
- The sensor was showing "unknown" because `update_interval: never` prevents the lambda from ever firing
- Now uses the default 60s periodic update to publish the version string