### PR TITLE
Fix: publish firmware version once on boot instead of polling

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -341,8 +341,7 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    lambda: |-
-      return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 script:

--- a/Integrations/ESPHome/PUMP-1.yaml
+++ b/Integrations/ESPHome/PUMP-1.yaml
@@ -4,6 +4,11 @@ esphome:
   comment: Apollo PUMP-1
   name_add_mac_suffix: true
   on_boot:
+  - priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
   - priority: -10
     then:
       - if:

--- a/Integrations/ESPHome/PUMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/PUMP-1_Minimal.yaml
@@ -8,6 +8,12 @@ esphome:
     version: "${version}"
 
   min_version: 2023.11.1
+  on_boot:
+    priority: 500
+    then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/PUMP-1/Integrations/ESPHome/PUMP-1_Minimal.yaml


### PR DESCRIPTION
## Summary
- Replaced the 60s polling lambda with a single `text_sensor.template.publish` on boot
- Added `update_interval: never` back to the sensor definition since the value is a compile-time constant
- Consistent with the same fix applied across AIR-1, PLT-1, TEMP-1, and BTN-1

Per ESPHome developer feedback: there's no need to poll a constant value every 60s — just publish it once at boot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored firmware version tracking to use explicit boot-time initialization instead of automatic periodic computation, improving configuration clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->