### PR TITLE
[cpap] Add logbook entry for auto refill trigger

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -245,6 +245,11 @@ binary_sensor:
                 - switch.is_off: pump_control
             then:
               - logger.log: "Auto refill triggered - tank level low"
+              - homeassistant.action:
+                  action: logbook.log
+                  data:
+                    name: "PUMP-1"
+                    message: "Auto refill triggered - tank level low"
               - script.execute: pumpUntilFull
 
   - platform: gpio


### PR DESCRIPTION
Version: 26.3.2.1

## What does this implement/fix?

Adds a Home Assistant logbook entry when the pump is automatically triggered by the **Auto Refill** + **Invert Water Logic** combination (CPAP auto-fill use case).

Previously, the pump would run silently in this mode with no logbook record in HA. Now, when `on_release` fires on the fluid input sensor and both switches are enabled, a `logbook.log` action is called before `pumpUntilFull` executes.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-refill actions now generate logbook entries in Home Assistant to track and document when automatic tank refills are triggered due to low water levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->