### PR TITLE
[cpap] Add Last Pump Action text sensor for HA logbook

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -173,9 +173,9 @@ switch:
                 - switch.is_off: stop_pump_when_dry
             then:
               - logger.log: "Pump turning on - conditions met"
-              - event.trigger:
-                  id: pump_activity_event
-                  event_type: pump_started
+              - text_sensor.template.publish:
+                  id: last_pump_action
+                  state: "Pump Started"
               - lambda: |-
                   id(pump_start_time) = millis();
                   id(safety_alert_active) = false;
@@ -190,9 +190,9 @@ switch:
               lambda: 'return id(pump_start_time) != 0;'
             then:
               - logger.log: "Pump turned off"
-              - event.trigger:
-                  id: pump_activity_event
-                  event_type: pump_stopped
+              - text_sensor.template.publish:
+                  id: last_pump_action
+                  state: "Pump Stopped"
         - lambda: |-
             id(pump_start_time) = 0;
             id(safety_alert_active) = false;
@@ -255,9 +255,9 @@ binary_sensor:
                 - switch.is_off: pump_control
             then:
               - logger.log: "Auto refill triggered - tank level low"
-              - event.trigger:
-                  id: pump_activity_event
-                  event_type: auto_refill_triggered
+              - text_sensor.template.publish:
+                  id: last_pump_action
+                  state: "Auto Refill Triggered"
               - script.execute: pumpUntilFull
 
   - platform: gpio
@@ -341,17 +341,11 @@ light:
           min_brightness: 50%
           max_brightness: 100%
 
-event:
-  - platform: template
-    name: "Pump Activity"
-    id: pump_activity_event
-    icon: mdi:pump
-    event_types:
-      - auto_refill_triggered
-      - pump_started
-      - pump_stopped
-
 text_sensor:
+  - platform: template
+    name: "Last Pump Action"
+    id: last_pump_action
+    icon: mdi:pump
   - platform: wifi_info
     ip_address:
       name: "IP Address"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -185,13 +185,17 @@ switch:
               - switch.turn_off: pump_control
     on_turn_off:
       then:
+        - if:
+            condition:
+              lambda: 'return id(pump_start_time) != 0;'
+            then:
+              - logger.log: "Pump turned off"
+              - event.trigger:
+                  id: pump_activity_event
+                  event_type: pump_stopped
         - lambda: |-
             id(pump_start_time) = 0;
             id(safety_alert_active) = false;
-        - logger.log: "Pump turned off"
-        - event.trigger:
-            id: pump_activity_event
-            event_type: pump_stopped
 
 binary_sensor:
   - platform: status

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -173,6 +173,9 @@ switch:
                 - switch.is_off: stop_pump_when_dry
             then:
               - logger.log: "Pump turning on - conditions met"
+              - event.trigger:
+                  id: pump_activity_event
+                  event_type: pump_started
               - lambda: |-
                   id(pump_start_time) = millis();
                   id(safety_alert_active) = false;
@@ -186,6 +189,9 @@ switch:
             id(pump_start_time) = 0;
             id(safety_alert_active) = false;
         - logger.log: "Pump turned off"
+        - event.trigger:
+            id: pump_activity_event
+            event_type: pump_stopped
 
 binary_sensor:
   - platform: status
@@ -245,11 +251,9 @@ binary_sensor:
                 - switch.is_off: pump_control
             then:
               - logger.log: "Auto refill triggered - tank level low"
-              - homeassistant.action:
-                  action: logbook.log
-                  data:
-                    name: "PUMP-1"
-                    message: "Auto refill triggered - tank level low"
+              - event.trigger:
+                  id: pump_activity_event
+                  event_type: auto_refill_triggered
               - script.execute: pumpUntilFull
 
   - platform: gpio
@@ -332,6 +336,16 @@ light:
           update_interval: 100ms
           min_brightness: 50%
           max_brightness: 100%
+
+event:
+  - platform: template
+    name: "Pump Activity"
+    id: pump_activity_event
+    icon: mdi:pump
+    event_types:
+      - auto_refill_triggered
+      - pump_started
+      - pump_stopped
 
 text_sensor:
   - platform: wifi_info


### PR DESCRIPTION
Version: 26.3.2.1

## What does this implement/fix?

Replaces the incorrect `homeassistant.action` logbook approach from #32 with a **Last Pump Action** template text sensor whose state changes appear verbatim in the HA logbook — no API actions required on the device.

The text sensor state is updated at three points:
- `"Auto Refill Triggered"` — CPAP auto refill + invert water logic triggers the pump via input sensor going dry
- `"Pump Started"` — pump_control turns on and conditions are met
- `"Pump Stopped"` — pump_control turns off after a successful start (guarded: not emitted on rejected starts)

The `pump_stopped` emission is guarded by checking `pump_start_time != 0` so that false logbook entries are not created when a start is rejected due to water conditions not being met.

Fixes the incorrect implementation in #32.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page