### PR TITLE
[ux] Rename Invert Water Logic to Tank Refill Mode + auto-configure switches

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -17,9 +17,20 @@ esphome:
             id(pump_start_time) = 0;
             id(safety_alert_active) = false;
         - script.execute: pump_safety_check
+    - priority: -20
+      then:
+        - if:
+            condition:
+              switch.is_on: tank_refill_mode
+            then:
+              - switch.turn_on: stop_pump_when_full
+              - switch.turn_off: stop_pump_when_dry
+            else:
+              - switch.turn_off: stop_pump_when_full
+              - switch.turn_on: stop_pump_when_dry
     - priority: -100
       then:
-        - delay: 1000ms 
+        - delay: 1000ms
         - script.execute: statusCheck
     - priority: -10
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -128,12 +128,20 @@ switch:
     icon: mdi:water-sync
     entity_category: config
   - platform: template
-    name: "Invert Water Logic"
-    id: invert_water_logic
+    name: "Tank Refill Mode"
+    id: tank_refill_mode
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
     icon: mdi:water-sync
     entity_category: config
+    on_turn_on:
+      then:
+        - switch.turn_on: stop_pump_when_full
+        - switch.turn_off: stop_pump_when_dry
+    on_turn_off:
+      then:
+        - switch.turn_off: stop_pump_when_full
+        - switch.turn_on: stop_pump_when_dry
   - platform: template
     name: "Auto Refill"
     id: auto_refill
@@ -163,11 +171,11 @@ switch:
               or:
                 # Normal mode: input has water
                 - and:
-                    - switch.is_off: invert_water_logic
+                    - switch.is_off: tank_refill_mode
                     - binary_sensor.is_on: fluid_input_sensor
                 # Inverted mode: input is dry (destination is low, needs filling)
                 - and:
-                    - switch.is_on: invert_water_logic
+                    - switch.is_on: tank_refill_mode
                     - binary_sensor.is_off: fluid_input_sensor
                 # Bypass: dry protection not enabled
                 - switch.is_off: stop_pump_when_dry
@@ -251,7 +259,7 @@ binary_sensor:
             condition:
               and:
                 - switch.is_on: auto_refill
-                - switch.is_on: invert_water_logic
+                - switch.is_on: tank_refill_mode
                 - switch.is_off: pump_control
             then:
               - logger.log: "Auto refill triggered - tank level low"
@@ -435,7 +443,7 @@ script:
             - if:
                 condition:
                   - and:
-                      - switch.is_on: invert_water_logic
+                      - switch.is_on: tank_refill_mode
                       - switch.is_off: stop_pump_when_full
                       - binary_sensor.is_on: fluid_input_sensor
                 then:
@@ -445,7 +453,7 @@ script:
                 condition:
                   - and:
                       - switch.is_on: stop_pump_when_dry
-                      - switch.is_off: invert_water_logic
+                      - switch.is_off: tank_refill_mode
                       - binary_sensor.is_off: fluid_input_sensor
                 then:
                   - logger.log: "Pump stopping - input dry"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -25,9 +25,11 @@ esphome:
             then:
               - switch.turn_on: stop_pump_when_full
               - switch.turn_off: stop_pump_when_dry
+              - switch.turn_on: auto_refill
             else:
               - switch.turn_off: stop_pump_when_full
               - switch.turn_on: stop_pump_when_dry
+              - switch.turn_off: auto_refill
     - priority: -100
       then:
         - delay: 1000ms
@@ -149,10 +151,12 @@ switch:
       then:
         - switch.turn_on: stop_pump_when_full
         - switch.turn_off: stop_pump_when_dry
+        - switch.turn_on: auto_refill
     on_turn_off:
       then:
         - switch.turn_off: stop_pump_when_full
         - switch.turn_on: stop_pump_when_dry
+        - switch.turn_off: auto_refill
   - platform: template
     name: "Auto Refill"
     id: auto_refill


### PR DESCRIPTION
Version: 26.3.2.1

## What does this implement/fix?

Two UX improvements for the CPAP/refill use case:

**1. Rename "Invert Water Logic" → "Tank Refill Mode"**
Renames the switch `name`, `id`, and all 4 condition references throughout the file. "Tank Refill Mode" is immediately clear to end users; "Invert Water Logic" required understanding of the internal implementation.

**2. Auto-configure related switches when Tank Refill Mode is toggled**
Enabling/disabling the mode now automatically sets the other switches to the correct values for that mode, so users don't have to configure them manually:

| Tank Refill Mode | Stop Pump When Output Wet | Stop Pump When Input Dry |
|---|---|---|
| Turns ON | → ON | → OFF |
| Turns OFF | → OFF | → ON |

This ensures correct behavior out of the box without requiring users to understand which combination of switches is needed.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [x] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the public switch from "Invert Water Logic" to "Tank Refill Mode".

* **New Features**
  * Tank Refill Mode now synchronizes related pump switches when toggled.
  * Device evaluates Tank Refill Mode at boot to initialize pump-related switches.
  * All pump and refill control logic updated to use the new Tank Refill Mode while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->