### PR TITLE
feat: add debounce filters to water level sensors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -268,6 +268,9 @@ binary_sensor:
         input: true
         pullup: true
       inverted: true
+    filters:
+      - delayed_on: 5s
+      - delayed_off: 5s
     on_release:
       then:
         - if:
@@ -285,7 +288,7 @@ binary_sensor:
 
   - platform: gpio
     name: Fluid Output
-    id: fulid_output_sensor
+    id: fluid_output_sensor
     icon: mdi:water
     device_class: moisture
     pin:
@@ -294,6 +297,8 @@ binary_sensor:
         input: true
         pullup: true
       inverted: true
+    filters:
+      - delayed_off: 5s
 
 number:
   - platform: template
@@ -442,7 +447,7 @@ script:
                 condition:
                   - and:
                       - switch.is_on: stop_pump_when_full
-                      - binary_sensor.is_on: fulid_output_sensor
+                      - binary_sensor.is_on: fluid_output_sensor
                 then:
                   - logger.log: "Pump stopping - tank full"
                   - switch.turn_off: pump_control


### PR DESCRIPTION
Version: 25.04.12.1

## What does this implement/fix?

Adds ESPHome `delayed_on`/`delayed_off` filters to the water level sensors to prevent sensor bounce caused by CPAP air intake waves. This stops HA logbook spam and prevents false refill triggers.

Also fixes a typo in the output sensor entity ID (`fulid_output_sensor` → `fluid_output_sensor`).

**Output sensor (tank full):**
- `delayed_off: 5s` — must read dry for 5 continuous seconds before reporting "not full"
- No `delayed_on` — pump stops immediately when sensor reads wet

**Input sensor (water level):**
- `delayed_on: 5s` — must read wet for 5 continuous seconds before confirming water presence
- `delayed_off: 5s` — must read dry for 5 continuous seconds before triggering auto-refill

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed typo in the Fluid Output sensor name and updated the pump safety script to reference the corrected sensor identifier for proper system operation

## Improvements
* Added input and output stabilization behavior with 5-second response delays to the Fluid Input and Output moisture sensors for more reliable and stable sensor readings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->