### PR TITLE
feat: configurable sensor debounce with stop-then-verify

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -76,6 +76,14 @@ globals:
     initial_value: "true"
   - id: testCycleCount
     type: int
+  - id: output_wet_count
+    type: int
+    restore_value: no
+    initial_value: '0'
+  - id: input_dry_count
+    type: int
+    restore_value: no
+    initial_value: '0'
 
 captive_portal:
 
@@ -202,6 +210,8 @@ switch:
               - lambda: |-
                   id(pump_start_time) = millis();
                   id(safety_alert_active) = false;
+                  id(output_wet_count) = 0;
+                  id(input_dry_count) = 0;
               - script.execute: pump_safety_check
             else:
               - logger.log: "Pump blocked - water conditions not met"
@@ -270,9 +280,11 @@ binary_sensor:
       inverted: true
     on_release:
       then:
+        - delay: !lambda 'return (int)id(sensor_debounce_seconds).state * 1000;'
         - if:
             condition:
               and:
+                - binary_sensor.is_off: fluid_input_sensor
                 - switch.is_on: auto_refill
                 - switch.is_on: tank_refill_mode
                 - switch.is_off: pump_control
@@ -285,7 +297,7 @@ binary_sensor:
 
   - platform: gpio
     name: Fluid Output
-    id: fulid_output_sensor
+    id: fluid_output_sensor
     icon: mdi:water
     device_class: moisture
     pin:
@@ -318,6 +330,20 @@ number:
     max_value: 600
     step: 10
     initial_value: 60
+    unit_of_measurement: "s"
+    restore_value: true
+    mode: box
+  - platform: template
+    name: "Sensor Debounce Seconds"
+    id: sensor_debounce_seconds
+    icon: mdi:timer-sand
+    entity_category: config
+    disabled_by_default: true
+    optimistic: true
+    min_value: 0
+    max_value: 30
+    step: 1
+    initial_value: 0
     unit_of_measurement: "s"
     restore_value: true
     mode: box
@@ -438,13 +464,37 @@ script:
           condition:
             - switch.is_on: pump_control
           then:
+            # Debounce counters for sensor readings
+            - lambda: |-
+                int debounce = (int)id(sensor_debounce_seconds).state;
+                // Output sensor wet counter (stop when full)
+                if (id(stop_pump_when_full).state && id(fluid_output_sensor).state) {
+                  id(output_wet_count) += 1;
+                } else if (id(tank_refill_mode).state && !id(stop_pump_when_full).state && id(fluid_input_sensor).state) {
+                  // Inverted mode: input sensor wet = destination full
+                  id(output_wet_count) += 1;
+                } else {
+                  id(output_wet_count) = 0;
+                }
+                // Input sensor dry counter (stop when dry)
+                if (id(stop_pump_when_dry).state && !id(tank_refill_mode).state && !id(fluid_input_sensor).state) {
+                  id(input_dry_count) += 1;
+                } else {
+                  id(input_dry_count) = 0;
+                }
             - if:
                 condition:
-                  - and:
-                      - switch.is_on: stop_pump_when_full
-                      - binary_sensor.is_on: fulid_output_sensor
+                  - lambda: |-
+                      int debounce = (int)id(sensor_debounce_seconds).state;
+                      return id(output_wet_count) > 0 && (debounce == 0 || id(output_wet_count) >= debounce);
                 then:
-                  - logger.log: "Pump stopping - tank full"
+                  - if:
+                      condition:
+                        - switch.is_on: stop_pump_when_full
+                      then:
+                        - logger.log: "Pump stopping - tank full"
+                      else:
+                        - logger.log: "Pump stopping - destination full (inverted mode)"
                   - switch.turn_off: pump_control
             - if:
                 condition:
@@ -457,19 +507,9 @@ script:
                   - switch.turn_off: pump_control
             - if:
                 condition:
-                  - and:
-                      - switch.is_on: tank_refill_mode
-                      - switch.is_off: stop_pump_when_full
-                      - binary_sensor.is_on: fluid_input_sensor
-                then:
-                  - logger.log: "Pump stopping - destination full (inverted mode)"
-                  - switch.turn_off: pump_control
-            - if:
-                condition:
-                  - and:
-                      - switch.is_on: stop_pump_when_dry
-                      - switch.is_off: tank_refill_mode
-                      - binary_sensor.is_off: fluid_input_sensor
+                  - lambda: |-
+                      int debounce = (int)id(sensor_debounce_seconds).state;
+                      return id(input_dry_count) > 0 && (debounce == 0 || id(input_dry_count) >= debounce);
                 then:
                   - logger.log: "Pump stopping - input dry"
                   - switch.turn_off: pump_control

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -76,14 +76,10 @@ globals:
     initial_value: "true"
   - id: testCycleCount
     type: int
-  - id: output_wet_count
-    type: int
+  - id: debounce_restart
+    type: bool
     restore_value: no
-    initial_value: '0'
-  - id: input_dry_count
-    type: int
-    restore_value: no
-    initial_value: '0'
+    initial_value: 'false'
 
 captive_portal:
 
@@ -191,31 +187,39 @@ switch:
       then:
         - if:
             condition:
-              or:
-                # Normal mode: input has water
-                - and:
-                    - switch.is_off: tank_refill_mode
-                    - binary_sensor.is_on: fluid_input_sensor
-                # Inverted mode: input is dry (destination is low, needs filling)
-                - and:
-                    - switch.is_on: tank_refill_mode
-                    - binary_sensor.is_off: fluid_input_sensor
-                # Bypass: dry protection not enabled
-                - switch.is_off: stop_pump_when_dry
+              - lambda: 'return id(debounce_restart);'
             then:
-              - logger.log: "Pump turning on - conditions met"
-              - text_sensor.template.publish:
-                  id: last_pump_action
-                  state: "Pump Started"
               - lambda: |-
-                  id(pump_start_time) = millis();
+                  id(debounce_restart) = false;
                   id(safety_alert_active) = false;
-                  id(output_wet_count) = 0;
-                  id(input_dry_count) = 0;
+              - logger.log: "Pump restarting after debounce verification"
               - script.execute: pump_safety_check
             else:
-              - logger.log: "Pump blocked - water conditions not met"
-              - switch.turn_off: pump_control
+              - if:
+                  condition:
+                    or:
+                      # Normal mode: input has water
+                      - and:
+                          - switch.is_off: tank_refill_mode
+                          - binary_sensor.is_on: fluid_input_sensor
+                      # Inverted mode: input is dry (destination is low, needs filling)
+                      - and:
+                          - switch.is_on: tank_refill_mode
+                          - binary_sensor.is_off: fluid_input_sensor
+                      # Bypass: dry protection not enabled
+                      - switch.is_off: stop_pump_when_dry
+                  then:
+                    - logger.log: "Pump turning on - conditions met"
+                    - text_sensor.template.publish:
+                        id: last_pump_action
+                        state: "Pump Started"
+                    - lambda: |-
+                        id(pump_start_time) = millis();
+                        id(safety_alert_active) = false;
+                    - script.execute: pump_safety_check
+                  else:
+                    - logger.log: "Pump blocked - water conditions not met"
+                    - switch.turn_off: pump_control
     on_turn_off:
       then:
         - if:
@@ -464,38 +468,31 @@ script:
           condition:
             - switch.is_on: pump_control
           then:
-            # Debounce counters for sensor readings
-            - lambda: |-
-                int debounce = (int)id(sensor_debounce_seconds).state;
-                // Output sensor wet counter (stop when full)
-                if (id(stop_pump_when_full).state && id(fluid_output_sensor).state) {
-                  id(output_wet_count) += 1;
-                } else if (id(tank_refill_mode).state && !id(stop_pump_when_full).state && id(fluid_input_sensor).state) {
-                  // Inverted mode: input sensor wet = destination full
-                  id(output_wet_count) += 1;
-                } else {
-                  id(output_wet_count) = 0;
-                }
-                // Input sensor dry counter (stop when dry)
-                if (id(stop_pump_when_dry).state && !id(tank_refill_mode).state && !id(fluid_input_sensor).state) {
-                  id(input_dry_count) += 1;
-                } else {
-                  id(input_dry_count) = 0;
-                }
+            # Stop when full (output wet) - stop first, verify after
             - if:
                 condition:
-                  - lambda: |-
-                      int debounce = (int)id(sensor_debounce_seconds).state;
-                      return id(output_wet_count) > 0 && (debounce == 0 || id(output_wet_count) >= debounce);
+                  - and:
+                      - switch.is_on: stop_pump_when_full
+                      - binary_sensor.is_on: fluid_output_sensor
                 then:
+                  - switch.turn_off: pump_control
                   - if:
                       condition:
-                        - switch.is_on: stop_pump_when_full
+                        - lambda: 'return id(sensor_debounce_seconds).state > 0;'
                       then:
-                        - logger.log: "Pump stopping - tank full"
+                        - delay: !lambda 'return (int)id(sensor_debounce_seconds).state * 1000;'
+                        - if:
+                            condition:
+                              - binary_sensor.is_off: fluid_output_sensor
+                            then:
+                              - logger.log: "Debounce: tank full was false alarm, restarting pump"
+                              - lambda: 'id(debounce_restart) = true;'
+                              - switch.turn_on: pump_control
+                            else:
+                              - logger.log: "Pump stopped - tank full (confirmed)"
                       else:
-                        - logger.log: "Pump stopping - destination full (inverted mode)"
-                  - switch.turn_off: pump_control
+                        - logger.log: "Pump stopping - tank full"
+            # Safety timeout (unchanged)
             - if:
                 condition:
                   - lambda: |-
@@ -505,14 +502,56 @@ script:
                 then:
                   - logger.log: "Pump stopping - safety"
                   - switch.turn_off: pump_control
+            # Destination full in inverted mode (input wet)
             - if:
                 condition:
-                  - lambda: |-
-                      int debounce = (int)id(sensor_debounce_seconds).state;
-                      return id(input_dry_count) > 0 && (debounce == 0 || id(input_dry_count) >= debounce);
+                  - and:
+                      - switch.is_on: tank_refill_mode
+                      - switch.is_off: stop_pump_when_full
+                      - binary_sensor.is_on: fluid_input_sensor
                 then:
-                  - logger.log: "Pump stopping - input dry"
                   - switch.turn_off: pump_control
+                  - if:
+                      condition:
+                        - lambda: 'return id(sensor_debounce_seconds).state > 0;'
+                      then:
+                        - delay: !lambda 'return (int)id(sensor_debounce_seconds).state * 1000;'
+                        - if:
+                            condition:
+                              - binary_sensor.is_off: fluid_input_sensor
+                            then:
+                              - logger.log: "Debounce: destination full was false alarm, restarting pump"
+                              - lambda: 'id(debounce_restart) = true;'
+                              - switch.turn_on: pump_control
+                            else:
+                              - logger.log: "Pump stopped - destination full (confirmed)"
+                      else:
+                        - logger.log: "Pump stopping - destination full (inverted mode)"
+            # Stop when dry (input dry)
+            - if:
+                condition:
+                  - and:
+                      - switch.is_on: stop_pump_when_dry
+                      - switch.is_off: tank_refill_mode
+                      - binary_sensor.is_off: fluid_input_sensor
+                then:
+                  - switch.turn_off: pump_control
+                  - if:
+                      condition:
+                        - lambda: 'return id(sensor_debounce_seconds).state > 0;'
+                      then:
+                        - delay: !lambda 'return (int)id(sensor_debounce_seconds).state * 1000;'
+                        - if:
+                            condition:
+                              - binary_sensor.is_on: fluid_input_sensor
+                            then:
+                              - logger.log: "Debounce: input dry was false alarm, restarting pump"
+                              - lambda: 'id(debounce_restart) = true;'
+                              - switch.turn_on: pump_control
+                            else:
+                              - logger.log: "Pump stopped - input dry (confirmed)"
+                      else:
+                        - logger.log: "Pump stopping - input dry"
             - delay: 1s
   - id: testScript
     then:


### PR DESCRIPTION
Version: 25.04.12.1

## What does this implement/fix?

Adds a configurable "Sensor Debounce Seconds" number entity that prevents false sensor readings (caused by CPAP air intake waves) from causing erratic pump behavior.

**How it works (stop-then-verify):**
1. Sensor triggers a stop condition → **pump stops immediately** (safe)
2. Waits the configured debounce seconds
3. Re-checks the sensor — if it cleared (was a wave bounce), **restarts the pump automatically**
4. If still triggered, pump stays off (genuine reading confirmed)

This is safer than delaying the stop — the pump is never running while a stop condition is active.

**Configuration:**
- **Disabled by default** — users must enable the entity in HA to use it
- **Default 0** = original behavior (no debounce, immediate stop, no restart)
- **Range 0-30 seconds** — adjustable from HA dashboard, no reflash needed

**Safety:**
- Safety timeout (`max_safe_run_time`) is preserved across debounce restarts — a bouncy sensor cannot keep the pump running indefinitely
- Debounce restarts bypass pump start condition checks (which could fail during bouncing) via a `debounce_restart` global flag

**Also included:**
- Fix typo in output sensor entity ID (`fulid_output_sensor` → `fluid_output_sensor`)
- Auto-refill trigger (`on_release`) respects debounce delay with check-wait-confirm pattern

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page