### PR TITLE
Add Firmware Channel switching and serve the end-user image for OTA

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,0 +1,91 @@
+name: Build and Publish Beta
+
+# Builds PUMP-1 firmware from the beta branch and publishes it as assets on a
+# rolling "beta-fw" pre-release. The on-device "Firmware Channel" select points
+# OTA updates at these assets. Stable firmware is built/published separately
+# by build.yml (push to main -> GitHub Pages).
+
+on:
+  push:
+    branches: [beta]
+    paths:
+      - 'Integrations/ESPHome/**'
+  workflow_dispatch:
+
+# Least privilege: read-only by default; only publish-beta is elevated to write.
+permissions:
+  contents: read
+
+jobs:
+  version:
+    name: Read version
+    runs-on: ubuntu-latest
+    outputs:
+      v: ${{ steps.read.outputs.v }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - id: read
+        run: |
+          v=$(awk '/substitutions:/ {f=1} f && /version:/ {print $2; exit}' \
+            Integrations/ESPHome/Core.yaml | tr -d '"')
+          echo "v=$v" >> "$GITHUB_OUTPUT"
+          echo "Beta version: $v"
+
+  build:
+    name: Build firmware
+    needs: version
+    # Beta serves OTA updates only, so it builds the end-user image
+    # (PUMP-1_Minimal.yaml), not the first-flash improv image.
+    uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df # 2026.4.1
+    with:
+      files: Integrations/ESPHome/beta-channel/PUMP-1_Minimal.yaml
+      esphome-version: stable
+      combined-name: firmware-beta
+      release-version: ${{ needs.version.outputs.v }}
+
+  publish-beta:
+    name: Publish beta release assets
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: fw
+          pattern: firmware*
+
+      - name: Ensure rolling 'beta-fw' pre-release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view beta-fw -R "${{ github.repository }}" >/dev/null 2>&1 \
+            || gh release create beta-fw -R "${{ github.repository }}" \
+                 --prerelease --title "Beta (rolling)" \
+                 --notes "Latest PUMP-1 beta firmware. Auto-updated on every push to the beta branch."
+
+      - name: Rewrite manifest to absolute URLs and upload assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE="https://github.com/${{ github.repository }}/releases/download/beta-fw"
+          man=$(find fw/firmware-beta -name manifest.json | head -1)
+          if [ -z "$man" ]; then
+            echo "::error::manifest.json not found"
+            exit 1
+          fi
+          echo "Rewriting $man"
+          # Make ota.path and parts[].path absolute release-asset URLs so the
+          # device never has to resolve a relative path against a redirect.
+          jq --arg base "$BASE" '
+            .builds[0].ota.path = ($base + "/" + (.builds[0].ota.path | sub(".*/"; "")))
+            | .builds[0].parts |= map(.path = ($base + "/" + (.path | sub(".*/"; ""))))
+          ' "$man" > manifest.json
+          cat manifest.json
+          gh release upload beta-fw manifest.json -R "${{ github.repository }}" --clobber
+          find fw/firmware-beta -name '*.bin' -print -exec \
+            gh release upload beta-fw {} -R "${{ github.repository }}" --clobber \;
+          echo "Beta assets published."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,13 @@ jobs:
       pull-requests: write
     with:
       device-name: pump-1
+      # PUMP-1_Minimal.yaml is the end-user image served at firmware/ (OTA
+      # updates and dashboard adoption). PUMP-1.yaml (improv + BLE) is only
+      # used for first flashes via the web installer.
       yaml-files: |
+        Integrations/ESPHome/PUMP-1_Minimal.yaml
         Integrations/ESPHome/PUMP-1.yaml
-      firmware-names: "1:firmware"
+      firmware-names: "1_Minimal:firmware,1:firmware-factory"
       core-yaml-path: Integrations/ESPHome/Core.yaml
       esphome-version: stable
       # Bypass check if manually triggered with bypass option

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,7 +1,16 @@
 substitutions:
   name: apollo-pump-1
-  version: "26.3.2.1"
+  version: "26.7.8.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
+  # Default update channel on first boot (no stored user choice yet, i.e. a
+  # fresh flash). The beta-channel builds override this to "Beta" (see
+  # Integrations/ESPHome/beta-channel/) so firmware obtained from the beta
+  # channel keeps tracking it instead of offering a stable "downgrade".
+  firmware_channel_default: "Stable"
+  # Manifest URL bases. Stable = GitHub Pages (main branch builds).
+  # Beta = rolling "beta" pre-release assets (beta branch builds).
+  stable_manifest_base: "https://apolloautomation.github.io/PUMP-1"
+  beta_manifest_base: "https://github.com/ApolloAutomation/PUMP-1/releases/download/beta-fw"
 
 esp32:
   variant: esp32c6
@@ -95,6 +104,41 @@ button:
   - platform: restart
     icon: mdi:power-cycle
     name: "ESP Reboot"
+
+  - platform: template
+    name: "Firmware Update"
+    id: update_firmware
+    icon: mdi:cloud-download
+    entity_category: "config"
+    on_press:
+      - logger.log: "Applying firmware based on selected channel"
+      # Free heap for the TLS download when BLE (improv) is active. Guarded
+      # so images without BLE compile the same YAML.
+      - lambda: |-
+          #ifdef USE_ESP32_BLE
+          if (esp32_ble::global_ble && esp32_ble::global_ble->is_active()) {
+            ESP_LOGI("firmware", "Disabling BLE for firmware update");
+            esp32_ble::global_ble->disable();
+          }
+          #endif
+      - delay: 3s
+      - script.execute: apply_ota_source
+      - script.wait: apply_ota_source
+      # The manifest fetch runs in its own task and YAML has no "fetch done"
+      # condition to wait on (update.is_available stays false for same-version
+      # switches), so give it a fixed window like R_PRO-1/CAST-1 do.
+      - delay: 5s
+      - update.perform:
+          id: update_http_request
+          force_update: true
+      # Only reached if the update did not start (e.g. manifest unreachable).
+      - lambda: |-
+          #ifdef USE_ESP32_BLE
+          if (esp32_ble::global_ble) {
+            ESP_LOGI("firmware", "Re-enabling BLE (no update performed)");
+            esp32_ble::global_ble->enable();
+          }
+          #endif
 
   - platform: factory_reset
     disabled_by_default: True
@@ -384,7 +428,36 @@ text_sensor:
     update_interval: never
     entity_category: "diagnostic"
 
+select:
+  - platform: template
+    name: "Firmware Channel"
+    id: firmware_channel
+    icon: mdi:source-branch
+    entity_category: "config"
+    optimistic: true
+    restore_value: true
+    options:
+      - "Stable"
+      - "Beta"
+    initial_option: "${firmware_channel_default}"
+    on_value:
+      then:
+        - script.execute: apply_ota_source
+
 script:
+  - id: apply_ota_source
+    # Sets the OTA manifest URL from the Firmware Channel select.
+    # Stable = GitHub Pages, Beta = rolling "beta" release assets.
+    then:
+      - lambda: |-
+          const bool beta = id(firmware_channel).current_option() == "Beta";
+          std::string url = beta
+            ? "${beta_manifest_base}/manifest.json"
+            : "${stable_manifest_base}/firmware/manifest.json";
+          ESP_LOGI("firmware", "OTA manifest set to: %s", url.c_str());
+          id(update_http_request).set_source_url(url);
+      - component.update: update_http_request
+
   - id: pumpUntilFull
     then:
       - switch.turn_on: stop_pump_when_full

--- a/Integrations/ESPHome/PUMP-1.yaml
+++ b/Integrations/ESPHome/PUMP-1.yaml
@@ -45,13 +45,13 @@ safe_mode:
 
 update:
   - platform: http_request
-    id: firmware_update
+    id: update_http_request
     name: Firmware Update
     source: https://apolloautomation.github.io/PUMP-1/firmware/manifest.json
 
 wifi:
   on_connect:
-    - component.update: firmware_update
+    - component.update: update_http_request
   ap:
     ssid: "Apollo PUMP-1 Hotspot"
 

--- a/Integrations/ESPHome/PUMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/PUMP-1_Minimal.yaml
@@ -22,8 +22,23 @@ dashboard_import:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/PUMP-1/firmware/manifest.json
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo PUMP-1 Hotspot"
 

--- a/Integrations/ESPHome/beta-channel/PUMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/beta-channel/PUMP-1_Minimal.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of PUMP-1_Minimal.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use PUMP-1_Minimal.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../PUMP-1_Minimal.yaml

--- a/static/index.html
+++ b/static/index.html
@@ -82,7 +82,7 @@
       <h1>Apollo PUMP-1 Installer</h1>
       
       <p class="button-row" align="center">
-        <esp-web-install-button manifest="./firmware/manifest.json">
+        <esp-web-install-button manifest="./firmware-factory/manifest.json">
         </esp-web-install-button>
       </p>
 


### PR DESCRIPTION
Version: 26.7.7.1

## What does this implement/fix?

Same Stable/Beta firmware switching as CAST-1 (naming per ApolloAutomation/CAST-1#43):

- **Firmware Channel** select (Stable/Beta) sets the OTA manifest URL via a new `apply_ota_source` script. Stable = GitHub Pages (main branch builds), Beta = rolling `beta` pre-release assets.
- **Firmware Update** button force-installs the selected channel's firmware. It re-applies the manifest URL first (so a just-switched channel is fetched before forcing) and temporarily disables BLE during the download to free heap for TLS (no-op on non-BLE images).
- **Updates now serve the end-user image**: `PUMP-1_Minimal.yaml` (the adopted end-user config) gains the managed update system, and CI serves it at `firmware/`; `PUMP-1.yaml` (improv + BLE) moves to `firmware-factory/` for the web installer only. Fielded devices leave the improv image on their next update.
- **build-beta.yml** (new): pushes to `beta` build the end-user image(s) and publish them to a rolling `beta` pre-release with manifests rewritten to absolute URLs.
- update component id renamed `firmware_update` -> `update_http_request` to match the other Apollo repos.

Both images config-validated on ESPHome 2026.6.4. Not yet tested on hardware.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
