### PR TITLE
Replace deprecated rgb_order with channel_colors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-pump-1
-  version: "26.3.2.1"
+  version: "26.8.27.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -347,7 +347,7 @@ light:
     default_transition_length: 0s
     chipset: WS2812
     num_leds: 1
-    rgb_order: grb
+    channel_colors: GRB
     # Add explicit power supply limit to prevent current spikes
     max_refresh_rate: 20ms
     effects:

--- a/Integrations/ESPHome/PUMP-1.yaml
+++ b/Integrations/ESPHome/PUMP-1.yaml
@@ -21,7 +21,7 @@ esphome:
     name: "ApolloAutomation.PUMP-1"
     version: "${version}"
 
-  min_version: 2023.11.1
+  min_version: 2026.8.0
 
 dashboard_import:
   package_import_url: github://ApolloAutomation/PUMP-1/Integrations/ESPHome/PUMP-1_Minimal.yaml

--- a/Integrations/ESPHome/PUMP-1_Minimal.yaml
+++ b/Integrations/ESPHome/PUMP-1_Minimal.yaml
@@ -7,7 +7,7 @@ esphome:
     name: "ApolloAutomation.PUMP-1"
     version: "${version}"
 
-  min_version: 2023.11.1
+  min_version: 2026.8.0
   on_boot:
     priority: 500
     then:


### PR DESCRIPTION
ESPHome 2026.8.0 replaces `rgb_order` / `is_rgbw` / `is_wrgb` with a single `channel_colors` key on `esp32_rmt_led_strip` ([esphome#18474](https://github.com/esphome/esphome/pull/18474)).

`channel_colors` takes each of `R`, `G`, `B` exactly once, optionally with a single `W`; the value is case-insensitive. No behaviour change — `grb` and `GRB` are equivalent, uppercase to match the ESPHome docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RGB LED strip color channel configuration for improved compatibility and correct color rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->